### PR TITLE
Fix coverage badge step to unblock main CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -189,9 +189,10 @@ jobs:
     - name: Create coverage badge
       uses: schneegans/dynamic-badges-action@v1.7.0
       if: github.ref == 'refs/heads/main'
+      continue-on-error: true
       with:
         auth: ${{ secrets.GITHUB_TOKEN }}
-        gist-id: zebrahoof-emr-coverage
+        gistID: zebrahoof-emr-coverage
         label: coverage
         message: ${{ steps.coverage.outputs.percentage }}%
         color: ${{ steps.coverage.outputs.color }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Main CI is failing after merge of PR #3 at the "Create coverage badge" step with:
- ❌ Unexpected input `gist-id` (valid parameter is `gistID`)
- ❌ Failed to get gist: 404 Not Found (gist `zebrahoof-emr-coverage` doesn't exist)
- This step only runs on main (`if: github.ref == 'refs/heads/main'`), which is why PRs were green

Failed run: https://github.com/rattaroaz/Zebrahoof-EMR/actions/runs/32751983701

## Solution
Workflow-only fixes:
1. **Fixed parameter name**: Changed `gist-id` → `gistID` (correct parameter for `schneegans/dynamic-badges-action@v1.7.0`)
2. **Added fault tolerance**: Added `continue-on-error: true` so the cosmetic badge step cannot fail the main CI pipeline

## Testing
- ✅ All other CI steps (build, tests, coverage merge/generate/thresholds) were already passing
- ✅ This PR will test the fixed badge step on main merge
- ✅ Even if gist still 404s, CI will now succeed with the `continue-on-error` guard

## Changes
- `.github/workflows/ci-cd.yml`: 2 line changes to "Create coverage badge" step
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcee6ca2-3c3f-47d9-9743-597979f9c1af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcee6ca2-3c3f-47d9-9743-597979f9c1af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

